### PR TITLE
Replaced rm_rf function in lib.py with shutil.rmtree.

### DIFF
--- a/icybackup/components/lib.py
+++ b/icybackup/components/lib.py
@@ -1,9 +1,0 @@
-import os
-
-def rm_rf(d):
-	for path in (os.path.join(d,f) for f in os.listdir(d)):
-		if os.path.isdir(path):
-			rm_rf(path)
-		else:
-			os.unlink(path)
-	os.rmdir(d)

--- a/icybackup/management/commands/backup.py
+++ b/icybackup/management/commands/backup.py
@@ -1,11 +1,11 @@
-import os, sys, time
+import os, sys, time, shutil
 from optparse import make_option
 from tempfile import mkdtemp, NamedTemporaryFile
 import tarfile
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
-from ...components import db, glacier, lib
+from ...components import db, glacier
 
 # Based on: http://code.google.com/p/django-backup/
 # Based on: http://www.djangosnippets.org/snippets/823/
@@ -82,7 +82,7 @@ class Command(BaseCommand):
 				sys.stdout.write(f.read())
 
 		# clean up
-		lib.rm_rf(backup_root)
+		shutil.rmtree(backup_root, ignore_errors=True)
 		if output_file_temporary:
 			os.unlink(output_file)
 

--- a/icybackup/management/commands/restore.py
+++ b/icybackup/management/commands/restore.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from distutils.dir_util import copy_tree
 
-from ...components import db, lib
+from ...components import db
 
 # Based on: http://code.google.com/p/django-backup/
 # Based on: http://www.djangosnippets.org/snippets/823/
@@ -62,6 +62,6 @@ class Command(BaseCommand):
 		copy_tree(os.path.join(backup_root, 'media'), media_root)
 		
 		# clean up
-		lib.rm_rf(extract_root)
+		shutil.rmtree(extract_root, ignore_errors=True)
 		if input_file_temporary:
 			os.unlink(input_file)


### PR DESCRIPTION
I came across a problem with icybackup when used in conjunction with django-antichaos, as antichaos creates a symlink in your app's media directory to its own media directory in its installation path.

Your components.lib.rm_rf function would follow the symlink, kill the contents of antichaos' media directory (in a virtualenv) and then fail to delete the symlink using os.rmdir() at the end of rm_rf().

Replacing components.lib.rm_rf with shutil.rmtree seemed to do the trick.
